### PR TITLE
security: remove hardcoded OURA_API_TOKEN fallback

### DIFF
--- a/scripts/telegram_bot.py
+++ b/scripts/telegram_bot.py
@@ -42,7 +42,10 @@ if not TELEGRAM_BOT_TOKEN:
     print("Error: TELEGRAM_BOT_TOKEN not set")
     sys.exit(1)
 
-OURA_API_TOKEN = os.environ.get("OURA_API_TOKEN", "5NTLJKPQTCBXBIOO2AKTNY5E2G6AZKIG")
+OURA_API_TOKEN = os.environ.get("OURA_API_TOKEN")
+if not OURA_API_TOKEN:
+    print("Error: OURA_API_TOKEN not set. Get it from https://cloud.ouraring.com/personal-access-tokens")
+    sys.exit(1)
 
 
 class OuraClient:


### PR DESCRIPTION
Fixes #3

**Security fix:** Removed hardcoded OURA_API_TOKEN fallback from telegram_bot.py

Before:
```python
OURA_API_TOKEN = os.environ.get("OURA_API_TOKEN", "5NTLJKPQTCBXBIOO2AKTNY5E2G6AZKIG")
```

After:
```python
OURA_API_TOKEN = os.environ.get("OURA_API_TOKEN")
if not OURA_API_TOKEN:
    print("Error: OURA_API_TOKEN not set. Get it from https://cloud.ouraring.com/personal-access-tokens")
    sys.exit(1)
```

Now fails fast with clear instructions instead of using a leaked token.