### PR TITLE
docs: fix weekly_report.py CLI usage in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,11 +76,11 @@ python scripts/oura_api.py readiness --days 7
 ### Generate Reports
 
 ```bash
-# Weekly summary
-python scripts/weekly_report.py --type weekly --days 7
+# Weekly summary (last 7 days)
+python scripts/weekly_report.py --days 7
 
-# Monthly trends
-python scripts/weekly_report.py --type monthly --days 30
+# Monthly trends (last 30 days)
+python scripts/weekly_report.py --days 30
 ```
 
 ### Trigger Alerts


### PR DESCRIPTION
## Problem
PR #22 introduced a documentation error - README shows  flag for , but the script only accepts  (no ).

## Fix
- Removed  and  from example commands
- Fixed examples to use only  flag (e.g., , )

## Testing
Verified with :
