### PR TITLE
fix: support Telegram @channel usernames (keep chat_id as string)

### DIFF
--- a/scripts/alerts.py
+++ b/scripts/alerts.py
@@ -94,7 +94,8 @@ def send_telegram(message, chat_id=None, bot_token=None):
         return False
 
     url = f"https://api.telegram.org/bot{bot_token}/sendMessage"
-    data = json.dumps({"chat_id": int(chat_id), "text": message, "parse_mode": "Markdown"}).encode("utf-8")
+    # Keep chat_id as string to support both numeric IDs and @channel usernames
+    data = json.dumps({"chat_id": chat_id, "text": message, "parse_mode": "Markdown"}).encode("utf-8")
 
     req = urllib.request.Request(url, data=data, headers={"Content-Type": "application/json"})
 

--- a/scripts/weekly_report.py
+++ b/scripts/weekly_report.py
@@ -193,7 +193,8 @@ def send_telegram(message, chat_id=None, bot_token=None):
         return False
 
     url = f"https://api.telegram.org/bot{bot_token}/sendMessage"
-    data = json.dumps({"chat_id": int(chat_id), "text": message, "parse_mode": "Markdown"}).encode("utf-8")
+    # Keep chat_id as string to support both numeric IDs and @channel usernames
+    data = json.dumps({"chat_id": chat_id, "text": message, "parse_mode": "Markdown"}).encode("utf-8")
 
     req = urllib.request.Request(url, data=data, headers={"Content-Type": "application/json"})
 


### PR DESCRIPTION
## Summary\nFixes a regression from the urllib migration.\n\n### Issue\nThe  cast breaks Telegram notifications for channel/group usernames like .\n\n### Changes\n- Remove  cast in both  and \n- Keep  as string to support both numeric IDs and @channel usernames\n\n### Files Modified\n- \n- 