### PR TITLE
fix: P2 cache bugs - typing, deduplication, retry parsing

### DIFF
--- a/scripts/cache.py
+++ b/scripts/cache.py
@@ -17,7 +17,7 @@ class OuraCache:
         self.cache_dir = cache_dir
         self.cache_dir.mkdir(parents=True, exist_ok=True)
 
-    def get(self, endpoint: str, date: str) -> Optional[dict]:
+    def get(self, endpoint: str, date: str) -> Optional[list]:
         """
         Get cached data for endpoint and date.
 
@@ -26,7 +26,7 @@ class OuraCache:
             date: ISO date string (YYYY-MM-DD)
 
         Returns:
-            Cached data dict or None if not cached
+            Cached data list (Oura API returns data: []) or None if not cached
         """
         cache_file = self._get_cache_path(endpoint, date)
         if not cache_file.exists():
@@ -38,7 +38,7 @@ class OuraCache:
         except (json.JSONDecodeError, IOError):
             return None
 
-    def set(self, endpoint: str, date: str, data: dict) -> None:
+    def set(self, endpoint: str, date: str, data: list) -> None:
         """
         Cache data for endpoint and date.
 


### PR DESCRIPTION
## Fixes #43

Three P2 bugs identified by Codex review:

### 1. Cache Type Hints Wrong
**Before:** `Optional[dict]`  
**After:** `Optional[list]`

Oura API returns `data: []` (list of records), not single dict. Type hints were misleading.

### 2. Duplicate Data Risk
**Problem:** `_get_with_cache()` combined cached + fresh data without deduplication  
**Fix:** Deduplicate by record ID after combining data

Prevents duplicate records when date ranges overlap between cached and fresh fetches.

### 3. Retry-After Parsing Fragile
**Problem:** `int(retry_after)` crashes on HTTP date strings  
**Fix:** Try int first, fallback to date parsing, fallback to 60s

HTTP Retry-After can be either seconds (int) or HTTP date string. Now handles both formats gracefully.

---

**Testing:**
- Manual verification of type hints
- Logic review of deduplication (by record ID)
- Retry-After parsing handles both formats + edge cases

**Ready for review.**