### PR TITLE
fix: use XDG cache location and daily_sleep endpoint

### DIFF
--- a/scripts/cache.py
+++ b/scripts/cache.py
@@ -19,7 +19,9 @@ class OuraCache:
             if env_cache_dir:
                 cache_dir = Path(env_cache_dir)
             else:
-                cache_dir = Path.home() / ".oura-analytics" / "cache"
+                # XDG-compliant default: ~/.cache/oura-analytics/
+                xdg_cache = os.environ.get("XDG_CACHE_HOME", str(Path.home() / ".cache"))
+                cache_dir = Path(xdg_cache) / "oura-analytics"
         self.cache_dir = cache_dir
         self.cache_dir.mkdir(parents=True, exist_ok=True)
 

--- a/scripts/daily_summary.py
+++ b/scripts/daily_summary.py
@@ -45,7 +45,11 @@ def main():
         client = OuraClient(args.token)
         
         # Fetch target day data
-        sleep_data = client.get_sleep(target_date, target_date)
+        # Try daily_sleep first (has scores), fall back to detailed sleep
+        sleep_data = client.get_daily_sleep(target_date, target_date)
+        if not sleep_data:
+            # Fall back to detailed sleep endpoint
+            sleep_data = client.get_sleep(target_date, target_date)
         readiness_data = client.get_readiness(target_date, target_date)
         
         if not sleep_data:


### PR DESCRIPTION
## Problem

1. **Cache location non-standard**: Defaulted to `~/.oura-analytics/cache/` instead of XDG-compliant `~/.cache/oura-analytics/`

2. **'No sleep data' errors**: The `/sleep` endpoint (detailed sessions) can lag days behind while `/daily_sleep` (scores) has current data. This caused the daily summary to report 'no data' even when the ring was worn.

## Changes

### cache.py
- Default to `~/.cache/oura-analytics/` (respects `XDG_CACHE_HOME`)
- Still honors `OURA_CACHE_DIR` env var for overrides

### daily_summary.py
- Try `daily_sleep` endpoint first (has current scores)
- Fall back to `sleep` endpoint if `daily_sleep` returns nothing

## Testing

Verified locally:
- `daily_sleep` returns data for Feb 1-4
- `sleep` stopped at Jan 28
- Daily summary now shows readiness score instead of 'no data'