### PR TITLE
docs: name the script entrypoints this skill owns

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -8,6 +8,8 @@ metadata: {"openclaw":{"requires":{"bins":["python3"],"env":["OURA_API_TOKEN"]},
 
 ## Quick Start
 
+**Owned entrypoints:** `daily_summary.py`, `daily-note.py`, `oura_api.py`, `alerts.py`, `weekly_report.py`.
+
 ```bash
 # Set Oura API token
 export OURA_API_TOKEN="your_personal_access_token"


### PR DESCRIPTION
## TL;DR

This skill's scripts are documented only as `scripts/<name>.py`, and my Opik weekly correction loop's matcher deliberately ignores a token preceded by `/` — so a `daily_summary.py` failure could never be traced back to the skill that owns it. I added one line naming the entrypoints as bare basenames.

## What Problem This Solves

The loop routes a repeated command failure at a guidance file only when that file names the failing command's head token. It reduces the failing command to its basename (`daily_summary.py`), while the token matcher refuses `/`-prefixed tokens so that a file path is not misread as a command mention.

The result is a systematic blind spot: every script this skill owns is referenced in path form, so `daily_summary.py` failures in my signal history resolved to *"no allowlisted file mentions `daily_summary.py`"* despite the script living in this repo.

## Why This Change Was Made

The bare basenames are the only form the matcher can bind to, so declaring them is the minimum change that closes the gap. I listed the five entrypoints that actually get invoked (including `daily-note.py`, which the cron path drives and which the `## Scripts` section did not previously list at all).

I put the line in the first `## ` section because the loop's inventory indexes H2 blocks as sections and ranks a section mention above a preamble mention. The existing `python scripts/...` usage lines are untouched.

## User Impact

- `daily_summary.py`, `daily-note.py`, `oura_api.py`, `alerts.py` and `weekly_report.py` failures route here at grounding 3, naming `Quick Start` as the section, instead of being filed with no owner.
- No metric, workflow, threshold, cron example or description changed. One added line.

## Evidence

Claimant check against a freshly generated 543-entry live skill inventory, using the real resolver:

```
daily_summary.py   before: 0 claimants   after: resolved  oura-analytics/SKILL.md (g3)
```

Sole claimant, so it routes rather than going ambiguous. This is one of ten declarations across my fleet that together take the W28 weekly bundle from 1 of 19 patch-eligible clusters routed to 6 of 19.

## Risk and Rollout

Very low: one additive line, no behavioural instruction touched. Rollback is a revert. It reaches the gateway through the normal boot-sync of the skill sources.

## AI Assistance

Implemented by a Claude Opus 5 subagent under my direction, with an explicit constraint to declare only entrypoints the skill genuinely owns. I am reviewing before merge.
